### PR TITLE
fixed missing php tag

### DIFF
--- a/includes/theme/image_settings.php
+++ b/includes/theme/image_settings.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class TEDxImageSettings {
 
   function __construct() {


### PR DESCRIPTION
To use PHP short open tag <? is discouraged since it is only available if enabled using the short_open_tag php.ini configuration file directive, or if PHP was configured with the --enable-short-tags option. -- none of both was my case, so I saw a non-interpreted PHP file inside HTML. 

More: http://php.net/manual/en/language.basic-syntax.phptags.php

Btw, grants for sharing this theme! Good job. :)