### PR TITLE
use relative vs. absolute path

### DIFF
--- a/assets/scss/initializers/_icons.scss
+++ b/assets/scss/initializers/_icons.scss
@@ -26,7 +26,7 @@
 }
 
 .ico:before {
-  background: transparent url('/wp-content/themes/tedx/images/small-sprite-ico.png') no-repeat left top;
+  background: transparent url('../../images/small-sprite-ico.png') no-repeat left top;
   width: 20px;
   height: 20px;
   display: block;


### PR DESCRIPTION
This will give better compatibility with child themes, different directory paths, or renamed theme folder.